### PR TITLE
feat: add endpoint to fetch game details by code

### DIFF
--- a/app/models/game.py
+++ b/app/models/game.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Literal
+from datetime import datetime
 
 
 class CreateGameRequest(BaseModel):
@@ -39,3 +40,15 @@ class LobbyResponse(BaseModel):
 class StartGameResponse(BaseModel):
     message: str
     board_size: Literal[3, 4, 5]
+
+
+class GameDetailResponse(BaseModel):
+    game_id: int
+    host_id: int
+    description: str
+    location: str
+    start_time: datetime
+    end_time: datetime
+    code: str
+    board_size: int | None
+    qr_img: str | None

--- a/app/routes/game.py
+++ b/app/routes/game.py
@@ -20,6 +20,7 @@ from app.models.game import (
     JoinGameResponse,
     LobbyResponse,
     StartGameResponse,
+    GameDetailResponse,
 )
 import random
 
@@ -197,3 +198,25 @@ def create_bingo_matrix(db: Session, game: Game, user_id: int):
             bingo_id=board.id
         )
         db.add(new_tile)
+
+
+@router.get("/games/{code}", response_model=GameDetailResponse)
+def get_game_details(code: str, db: Session = Depends(get_db)):
+    game = db.query(Game).filter(Game.code == code).first()
+
+    if not game:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    return GameDetailResponse(
+        game_id=game.id,
+        host_id=game.host_id,
+        description=game.description,
+        location=game.location,
+        start_time=game.start_time,
+        end_time=game.end_time,
+        code=game.code,
+        board_size=game.board_size,
+        qr_img=f"data:image/png;base64,{game.qr_img}" if game.qr_img else None
+    )
+
+


### PR DESCRIPTION
Closes  #14
Added a new endpoint to fetch game details using the game code.

## Changes
- Added GET /games/{code} endpoint
- Returns all details from the Game table
- Added GameDetailResponse model
- Returns 404 when game is not found

