### PR TITLE
feat: add endpoint to fetch bingo board for a user

### DIFF
--- a/app/models/game.py
+++ b/app/models/game.py
@@ -52,3 +52,16 @@ class GameDetailResponse(BaseModel):
     code: str
     board_size: int | None
     qr_img: str | None
+
+class TileResponse(BaseModel):
+    id: int
+    row: int
+    col: int
+    bingo_char: str
+
+class BingoBoardResponse(BaseModel):
+    bingo_id: int
+    user_id: int
+    game_id: int
+    points: int
+    tiles: list[TileResponse]

--- a/app/models/game.py
+++ b/app/models/game.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Literal
+from datetime import datetime
 
 
 class CreateGameRequest(BaseModel):
@@ -39,3 +40,15 @@ class LobbyResponse(BaseModel):
 class StartGameResponse(BaseModel):
     message: str
     board_size: Literal[3, 4, 5]
+
+
+class GameDetailResponse(BaseModel):
+    game_id: int
+    host_id: int
+    description: str
+    location: str
+    start_time: datetime
+    end_time: datetime
+    code: str
+    board_size: int | None
+    qr_img: str | None

--- a/app/routes/game.py
+++ b/app/routes/game.py
@@ -21,6 +21,8 @@ from app.models.game import (
     LobbyResponse,
     StartGameResponse,
     GameDetailResponse,
+    BingoBoardResponse,  
+    TileResponse,
 )
 import random
 
@@ -219,4 +221,40 @@ def get_game_details(code: str, db: Session = Depends(get_db)):
         qr_img=f"data:image/png;base64,{game.qr_img}" if game.qr_img else None
     )
 
+
+@router.get("/games/{code}/board/{user_id}", response_model=BingoBoardResponse)
+def get_user_board(code: str, user_id: int, db: Session = Depends(get_db)):
+    
+    
+    game = db.query(Game).filter(Game.code == code).first()
+    if not game:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    
+    board = db.query(Bingo).filter_by(game_id=game.id, user_id=user_id).first()
+    if not board:
+        raise HTTPException(status_code=404, detail="Board not found")
+
+    
+    tiles = (
+        db.query(BingoTiles)
+        .filter(BingoTiles.bingo_id == board.id)
+        .order_by(BingoTiles.row, BingoTiles.col)
+        .all()
+    )
+
+    return BingoBoardResponse(
+        bingo_id=board.id,
+        user_id=board.user_id,
+        game_id=board.game_id,
+        points=board.points,
+        tiles=[
+            TileResponse(
+                id=tile.id,
+                row=tile.row,
+                col=tile.col,
+                bingo_char=tile.bingo_char
+            ) for tile in tiles
+        ]
+    )
 

--- a/app/routes/game.py
+++ b/app/routes/game.py
@@ -20,6 +20,7 @@ from app.models.game import (
     JoinGameResponse,
     LobbyResponse,
     StartGameResponse,
+    GameDetailResponse,
 )
 import random
 
@@ -197,3 +198,25 @@ def create_bingo_matrix(db: Session, game: Game, user_id: int):
             bingo_id=board.id
         )
         db.add(new_tile)
+
+
+@router.get("/games/{code}", response_model=GameDetailResponse)
+def get_game_details(code: str, db: Session = Depends(get_db)):
+    game = db.query(Game).filter(Game.code == code).first()
+
+    if not game:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    return GameDetailResponse(
+        game_id=game.id,
+        host_id=game.host_id,
+        description=game.description,
+        location=game.location,
+        start_time=game.start_time,
+        end_time=game.end_time,
+        code=game.code,
+        board_size=game.board_size,
+        qr_img=f"data:image/png;base64,{game.qr_img}" if game.qr_img else None
+    )
+
+


### PR DESCRIPTION
Fixes #13

## Summary
Added a GET endpoint to fetch the bingo board of a user for a specific game.

## Changes
- Added GET /games/{code}/board/{user_id}
- Fetches game using code
- Fetches user's board using game_id and user_id
- Returns board tiles ordered by row and column
- Returns 404 if game or board is not found

Tested locally using PostgreSQL with seeded users and test games.
