### PR TITLE
feat: add update user profile endpoint

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -19,7 +19,7 @@ class User(Base):
     name = Column(String, nullable=False)
     email = Column(String, unique=True, nullable=False)
     code = Column(String, unique=True, nullable=False)
-    profile_image = Column(String, nullable=True, default="uploads/default.png")
+    profile_image = Column(String, nullable=True, default="/uploads/default.png")
 
     game_user_bingo = relationship("Bingo", back_populates="user")
 

--- a/app/models/profile.py
+++ b/app/models/profile.py
@@ -18,9 +18,3 @@ class UpdateUserRequest(BaseModel):
     username: str | None = None
     name: str | None = None
 
-class UserProfileResponse(BaseModel):
-    user_id: int
-    username: str
-    name: str
-    email: str        
-    profile_image: str | None = None

--- a/app/models/profile.py
+++ b/app/models/profile.py
@@ -13,3 +13,14 @@ class UserProfileResponse(BaseModel):
     name: str
     email: str
     profile_image: str
+
+class UpdateUserRequest(BaseModel):
+    username: str | None = None
+    name: str | None = None
+
+class UserProfileResponse(BaseModel):
+    user_id: int
+    username: str
+    name: str
+    email: str        
+    profile_image: str | None = None

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -6,7 +6,7 @@ import os
 
 from app.db.db import get_db
 from app.db.models import User
-from app.models.profile import UploadImageResponse, UserProfileResponse
+from app.models.profile import UploadImageResponse, UserProfileResponse, UpdateUserRequest
 
 router = APIRouter()
 
@@ -66,5 +66,39 @@ def get_user_profile(user_id: int, db: Session = Depends(get_db)):
         name=user.name,
         email=user.email,
         profile_image=image
+    )
+
+
+@router.patch("/profile/{user_id}", response_model=UserProfileResponse)
+def update_user_profile(
+    user_id: int,
+    data: UpdateUserRequest,
+    db: Session = Depends(get_db),
+):
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if data.username is not None:
+        existing = db.query(User).filter(
+            User.username == data.username,
+            User.id != user_id
+        ).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Username already taken")
+        user.username = data.username
+
+    if data.name is not None:
+        user.name = data.name
+
+    db.commit()
+    db.refresh(user)
+
+    return UserProfileResponse(
+        user_id=user.id,
+        username=user.username,
+        name=user.name,
+        email=user.email,
+        profile_image=user.profile_image if user.profile_image else "/uploads/default.png"
     )
 


### PR DESCRIPTION
## Description
Added a PATCH endpoint that allows users to update their profile details.
Fixes #10 

## What changed
- Added `PATCH /api/profile/{user_id}` endpoint
- Users can only update `username` and `name`
- Username uniqueness check added
- Added `UpdateUserRequest` model (username, name only)