### PR TITLE
fix: run push_to_prod only on merging PR

### DIFF
--- a/.github/workflows/push_to_prod.yaml
+++ b/.github/workflows/push_to_prod.yaml
@@ -1,10 +1,13 @@
-name: Push to production
 on:
   pull_request_target:
+    types:
+      - closed
     branches:
       - prod
+
 jobs:
-  build: 
+  build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH


### PR DESCRIPTION
Previously it was triggered by creating a PR. That has been rectified in this PR to run only upon merging of the PR 